### PR TITLE
move `col-ready` styles to `row > *`

### DIFF
--- a/assets/scss/_component-examples.scss
+++ b/assets/scss/_component-examples.scss
@@ -48,7 +48,6 @@
 }
 
 .example-content-main {
-  @include make-col-ready();
 
   @include media-breakpoint-up(sm) {
     @include make-col(6);
@@ -60,7 +59,6 @@
 }
 
 .example-content-secondary {
-  @include make-col-ready();
 
   @include media-breakpoint-up(sm) {
     @include make-col(6);

--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -4,28 +4,9 @@
 // any value of `$grid-columns`.
 
 @mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
-  // Common properties for all breakpoints
-  %grid-column {
-    position: relative;
-    width: 100%;
-    min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
-  }
 
   @each $breakpoint in map-keys($breakpoints) {
     $infix: breakpoint-infix($breakpoint, $breakpoints);
-
-    // Allow columns to stretch full width below their breakpoints
-    @for $i from 1 through $columns {
-      .col#{$infix}-#{$i} {
-        @extend %grid-column;
-      }
-    }
-    .col#{$infix},
-    .col#{$infix}-auto {
-      @extend %grid-column;
-    }
 
     @include media-breakpoint-up($breakpoint, $breakpoints) {
       // Provide basic `.col-{bp}` classes for equal-width flexbox columns

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -25,17 +25,16 @@
   flex-wrap: wrap;
   margin-right: ($grid-gutter-width / -2);
   margin-left: ($grid-gutter-width / -2);
-}
-
-@mixin make-col-ready() {
-  position: relative;
-  // Prevent columns from becoming too narrow when at smaller grid tiers by
-  // always setting `width: 100%;`. This works because we use `flex` values
-  // later on to override this initial width.
-  width: 100%;
-  min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
+  & > * {
+    position: relative;
+    // Prevent columns from becoming too narrow when at smaller grid tiers by
+    // always setting `width: 100%;`. This works because we use `flex` values
+    // later on to override this initial width.
+    width: 100%;
+    min-height: 1px; // Prevent collapsing
+    padding-right: ($grid-gutter-width / 2);
+    padding-left: ($grid-gutter-width / 2);
+  }
 }
 
 @mixin make-col($size, $columns: $grid-columns) {


### PR DESCRIPTION
The styles in the `make-col-ready` mixin can be more efficiently applied, and IMO be more in keeping with the dynamics of flexbox (i.e. `container > item` structure), and save some bytes of CSS, if they are applied as part of the `make-row` mixin using a direct-child universal selector. This is possible because `.col-` classed elements are required to be direct children of `.row` elements.

These changes will affect the grid setup mixins' output as well.